### PR TITLE
[FIX] Prevent swipe to dismiss on iOS

### DIFF
--- a/ios/ReactNativeShareExtension.m
+++ b/ios/ReactNativeShareExtension.m
@@ -16,6 +16,10 @@ NSExtensionContext* extensionContext;
     return nil;
 }
 
+- (BOOL)isModalInPresentation {
+    return true;
+}
+
 RCT_EXPORT_MODULE();
 
 - (void)viewDidLoad

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-extensions-share",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Share-Extension using react-native for both ios and android",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Swipe down to dismiss on iOS leaves the share extension in memory.
A later call to the share extension would hit memory limit and crash.